### PR TITLE
Rolling back to 2.7.0

### DIFF
--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: tensorflow
-  version: 2.9.3
+  version: 2.8.4
 
 about:
   home: https://tensorflow.org

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -26,12 +26,24 @@ requirements:
     - python=3.7
     - numpy
     - h5py
+    - protobuf # 3.20.3 is what pip pulls in
+    - certifi # 2024.2.28 is what pip pulls in
+    - importlib-metadata # 6.7.0 is what pip pulls in
+    - six # 1.16.0 is what pip pulls in
+    - typing-extensions # 4.7.1 is what pip pulls in
+    - zipp # 3.15.0 is what pip pulls in
     - pip
 
   run:
     - python=3.7
     - numpy
     - h5py
+    - protobuf
+    - certifi
+    - importlib-metadata
+    - six
+    - typing-extensions
+    - zipp
     - pip
 
 test:

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -12,7 +12,7 @@ about:
   For GPU support, install cudatoolkit 11.3.1 and cudnn 8.2.1 which are available as conda packages on the default channel.'
 
 build:
-  number: 2
+  number: 4
 
 source:
   path: ../

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: tensorflow
-  version: 2.8.4
+  version: 2.7.4
 
 about:
   home: https://tensorflow.org

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: tensorflow
-  version: 2.10.1
+  version: 2.9.3
 
 about:
   home: https://tensorflow.org

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -24,10 +24,14 @@ requirements:
 
   host:
     - python=3.7
+    - numpy
+    - h5py
     - pip
 
   run:
     - python=3.7
+    - numpy
+    - h5py
     - pip
 
 test:

--- a/.conda.tensorflow/meta.yaml
+++ b/.conda.tensorflow/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
   name: tensorflow
-  version: 2.7.4
+  version: 2.7.0
 
 about:
   home: https://tensorflow.org
@@ -12,7 +12,7 @@ about:
   For GPU support, install cudatoolkit 11.3.1 and cudnn 8.2.1 which are available as conda packages on the default channel.'
 
 build:
-  number: 1
+  number: 2
 
 source:
   path: ../

--- a/.github/workflows/build_tensorflow.yml
+++ b/.github/workflows/build_tensorflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - elizabeth/Change-Tensorflow-version
     paths:
       - '.github/workflows/build_tensorflow.yml'
       - '.conda.tensorflow/**'
@@ -18,7 +17,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # os: ["ubuntu-20.04", "windows-2019", "macos-10.15"]
         os: ["ubuntu-22.04", "windows-2022"]
     steps:
       # Setup
@@ -57,11 +55,6 @@ jobs:
         shell: bash -l {0}
         run: |
           conda build .conda.tensorflow --output-folder build.tensorflow -c conda-forge
-      # - name: Build conda package (Mac)
-      #   if: matrix.os == 'macos-10.15'
-      #   shell: bash -l {0}
-      #   run: |
-      #     conda build .conda.tensorflow --output-folder build.tensorflow
 
       # Upload conda package
       - name: Upload to Anaconda (Windows)
@@ -82,12 +75,3 @@ jobs:
           anaconda login --username sleap --password "$ANACONDA_LOGIN"
           anaconda -v upload build.tensorflow/linux-64/*.tar.bz2 --label dev
           anaconda logout
-      # - name: Upload to Anaconda (Mac)
-      #   if: matrix.os == 'macos-10.15'
-      #   env:
-      #     ANACONDA_LOGIN: ${{ secrets.ANACONDA_LOGIN }}
-      #   shell: bash -l {0}
-      #   run: |
-      #     anaconda login --username sleap --password "$ANACONDA_LOGIN"
-      #     anaconda -v upload build.tensorflow/osx-64/*.tar.bz2
-      #     anaconda logout

--- a/.github/workflows/build_tensorflow.yml
+++ b/.github/workflows/build_tensorflow.yml
@@ -70,7 +70,7 @@ jobs:
         shell: powershell
         run: |
           anaconda login --username sleap --password "$env:ANACONDA_LOGIN"
-          anaconda -v upload "build.tensorflow\win-64\*.tar.bz2"
+          anaconda -v upload "build.tensorflow\win-64\*.tar.bz2" --label dev
           anaconda logout
       - name: Upload to Anaconda (Ubuntu)
         if: matrix.os == 'ubuntu-22.04'
@@ -79,7 +79,7 @@ jobs:
         shell: bash -l {0}
         run: |
           anaconda login --username sleap --password "$ANACONDA_LOGIN"
-          anaconda -v upload build.tensorflow/linux-64/*.tar.bz2
+          anaconda -v upload build.tensorflow/linux-64/*.tar.bz2 --label dev
           anaconda logout
       # - name: Upload to Anaconda (Mac)
       #   if: matrix.os == 'macos-10.15'

--- a/.github/workflows/build_tensorflow.yml
+++ b/.github/workflows/build_tensorflow.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - elizabeth/Change-Tensorflow-version
     paths:
       - '.github/workflows/build_tensorflow.yml'
       - '.conda.tensorflow/**'

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,1 +1,2 @@
-tensorflow==2.10.1
+# tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
+tensorflow==2.9.3

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,2 +1,2 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-tensorflow==2.7.4 # 2.7.0 worked in the past
+tensorflow==2.7.0 # 2.7.0 worked in the past

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,3 +1,2 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-# tensorflow==2.9.3
 tensorflow==2.8.4

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,2 +1,3 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-tensorflow==2.9.3
+# tensorflow==2.9.3
+tensorflow==2.8.4

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,2 +1,2 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-tensorflow==2.8.4 # I don't see windows version on anaconda, pushing again
+tensorflow==2.7.4 # 2.7.0 worked in the past

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,2 +1,2 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-tensorflow==2.8.4 # server overloaded, need to push again
+tensorflow==2.8.4 # I don't see windows version on anaconda, pushing again

--- a/requirements.tensorflow.txt
+++ b/requirements.tensorflow.txt
@@ -1,2 +1,2 @@
 # tensorflow==2.10.1  # https://github.com/talmolab/sleap/issues/1721
-tensorflow==2.8.4
+tensorflow==2.8.4 # server overloaded, need to push again


### PR DESCRIPTION
- Bumped build number to 4
- Added h5py and numpy as conda dependencies so that they are not pip installed 